### PR TITLE
fix makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -33,7 +33,7 @@ single-c:
 
 
 # compiler setup
-CC = clang
+CC ?= clang
 ifeq ($(CC),gcc)
 CCFLAGS = -Wno-parentheses
 else


### PR DESCRIPTION
cc can now be set by environment variable, use CC=gcc for systems without clang (ie, mine)