### PR TITLE
makefile: detect prefixed gcc properly

### DIFF
--- a/makefile
+++ b/makefile
@@ -36,7 +36,7 @@ single-c:
 
 # compiler setup
 CC = clang
-ifeq ($(CC),gcc)
+ifneq ($(findstring gcc, $(CC)),)
 CCFLAGS = -Wno-parentheses
 else
 CCFLAGS = -Wno-microsoft-anon-tag


### PR DESCRIPTION
When cross-compiling, we'll have CC=aarch64-unknown-linux-gcc or similar.