### PR TITLE
Implement `•ReBQN` primitives

### DIFF
--- a/genRuntime
+++ b/genRuntime
@@ -5,7 +5,7 @@ args←•args
 path←⊑•args
 CC ← {𝕨 •FChars ⟨1,path,𝕩⟩ •Import "cc.bqn"}
 "src/gen/src" •FChars "#define RT_SRC 0"∾@+10
- "src/gen/compiler"CC"c"
+ "src/gen/compiles"CC"cc"
  "src/gen/runtime0"CC"r0"
  "src/gen/runtime1"CC"r1"
 "src/gen/formatter"CC"f"

--- a/makefile
+++ b/makefile
@@ -124,9 +124,9 @@ ${bd}/%.o: src/builtins/%.c
 
 src/gen/customRuntime:
 	@echo "Copying precompiled bytecode from the bytecode branch"
-	git checkout remotes/origin/bytecode src/gen/{compiler,formatter,runtime0,runtime1,src}
-	git reset src/gen/{compiler,formatter,runtime0,runtime1,src}
-${bd}/load.o: src/gen/customRuntime
+	git checkout remotes/origin/bytecode src/gen/{compiles,formatter,runtime0,runtime1,src}
+	git reset src/gen/{compiles,formatter,runtime0,runtime1,src}
+${bd}/load.o: src/gen/compiles
 
 
 

--- a/makefile
+++ b/makefile
@@ -126,7 +126,7 @@ src/gen/customRuntime:
 	@echo "Copying precompiled bytecode from the bytecode branch"
 	git checkout remotes/origin/bytecode src/gen/{compiles,formatter,runtime0,runtime1,src}
 	git reset src/gen/{compiles,formatter,runtime0,runtime1,src}
-${bd}/load.o: src/gen/compiles
+${bd}/load.o: src/gen/customRuntime
 
 
 

--- a/src/builtins/sysfn.c
+++ b/src/builtins/sysfn.c
@@ -527,7 +527,6 @@ B reBQN_c1(B t, B x) {
   if (!isNsp(x)) thrM("•ReBQN: Argument must be a namespace");
   B repl = ns_getNUf(x, m_str8l("repl"));
   B prim = ns_getNUf(x, m_str8l("primitives"));
-  dec(x);
   i32 replVal = q_N(repl) || eqStr(repl,U"none")? 0 : eqStr(repl,U"strict")? 1 : eqStr(repl,U"loose")? 2 : 3;
   if (replVal==3) thrM("•ReBQN: Invalid repl value");
   Block* initBlock = bqn_comp(m_str8l("\"(REPL initializer)\""), inc(cdPath), m_f64(0));
@@ -541,6 +540,7 @@ B reBQN_c1(B t, B x) {
   ptr_dec(initBlock);
   B dat = m_hVec4(m_f64(replVal), scVal, bi_N, bi_N);
   init_comp(harr_ptr(dat)+2, prim);
+  dec(x);
   return m_nfn(reBQNDesc, dat);
 }
 B repl_c2(B t, B w, B x) {

--- a/src/builtins/sysfn.c
+++ b/src/builtins/sysfn.c
@@ -538,33 +538,17 @@ B reBQN_c1(B t, B x) {
     scVal = tag(sc,OBJ_TAG);
   }
   ptr_dec(initBlock);
-  B dat = m_hVec4(m_f64(replVal), scVal, bi_N, bi_N);
-  init_comp(harr_ptr(dat)+2, prim);
+  HArr_p d = m_harrUv(5); d.a[0] = m_f64(replVal); d.a[1] = scVal;
+  d.a[2]=d.a[3]=d.a[4]=bi_N;
+  init_comp(d.a+2, prim);
   dec(x);
-  return m_nfn(reBQNDesc, dat);
+  return m_nfn(reBQNDesc, d.b);
 }
 B repl_c2(B t, B w, B x) {
   vfyStr(x, "REPL", "𝕩");
-  B o = nfn_objU(t);
-  B* op = harr_ptr(o);
-  i32 replMode = o2iu(op[0]);
-  Scope* sc = c(Scope, op[1]);
-  
   B fullpath;
   B args = args_path(&fullpath, w, "REPL");
-  
-  B res;
-  if (replMode>0) {
-    Block* block = bqn_compScc(x, fullpath, args, sc, op[2], op[3], replMode==2);
-    ptr_dec(sc->body);
-    sc->body = ptr_inc(block->bodies[0]);
-    res = execBlockInline(block, sc);
-    ptr_dec(block);
-  } else {
-    res = rebqn_exec(x, fullpath, args, op[2], op[3]);
-  }
-  
-  return res;
+  return rebqn_exec(x, fullpath, args, nfn_objU(t));
 }
 B repl_c1(B t, B x) {
   return repl_c2(t, emptyHVec(), x);
@@ -812,6 +796,7 @@ B sh_c2(B t, B w, B x) {
 
 B getInternalNS(void);
 B getMathNS(void);
+B getPrimitives(void);
 
 static Body* file_nsGen;
 B sys_c1(B t, B x) {
@@ -864,6 +849,7 @@ B sys_c1(B t, B x) {
     else if (eqStr(c, U"makerand")) r.a[i] = incG(bi_makeRand);
     else if (eqStr(c, U"rand")) r.a[i] = getRandNS();
     else if (eqStr(c, U"rebqn")) r.a[i] = incG(bi_reBQN);
+    else if (eqStr(c, U"primitives")) r.a[i] = getPrimitives();
     else if (eqStr(c, U"fromutf8")) r.a[i] = incG(bi_fromUtf8);
     else if (eqStr(c, U"path")) r.a[i] = inc(REQ_PATH);
     else if (eqStr(c, U"name")) r.a[i] = inc(REQ_NAME);

--- a/src/builtins/sysfn.c
+++ b/src/builtins/sysfn.c
@@ -561,7 +561,7 @@ B repl_c2(B t, B w, B x) {
     res = execBlockInline(block, sc);
     ptr_dec(block);
   } else {
-    res = bqn_exec(x, fullpath, args);
+    res = rebqn_exec(x, fullpath, args, op[2], op[3]);
   }
   
   return res;

--- a/src/core/harr.h
+++ b/src/core/harr.h
@@ -63,6 +63,7 @@ static void harr_abandon(HArr_p p) { VTY(p.b, t_harrPartial);
   value_free((Value*)p.c);
 }
 
+// unsafe-ish things - don't allocate/GC anything before having written to all items
 static HArr_p m_harrUv(usz ia) {
   HArr* r = m_arr(fsizeof(HArr,a,B,ia), t_harr, ia);
   arr_shVec((Arr*)r);

--- a/src/load.c
+++ b/src/load.c
@@ -356,10 +356,11 @@ void load_init() { // very last init function
     B prevAsrt = runtime[n_asrt];
     runtime[n_asrt] = bi_casrt; // horrible but GC is off so it's fiiiiiine
     Block* comp_b = load_compImport(
-      #include "gen/compiler"
+      #include "gen/compiles"
     );
     runtime[n_asrt] = prevAsrt;
-    load_comp = m_funBlock(comp_b, 0); ptr_dec(comp_b);
+    B glyphs = m_hVec3(m_str32(U"+-×÷⋆√⌊⌈|¬∧∨<>≠=≤≥≡≢⊣⊢⥊∾≍⋈↑↓↕«»⌽⍉/⍋⍒⊏⊑⊐⊒∊⍷⊔!"), m_str32(U"˙˜˘¨⌜⁼´˝`"), m_str32(U"∘○⊸⟜⌾⊘◶⎉⚇⍟⎊"));
+    load_comp = c1(m_funBlock(comp_b, 0), glyphs); ptr_dec(comp_b);
     gc_add(load_comp);
     
     

--- a/src/load.c
+++ b/src/load.c
@@ -164,7 +164,7 @@ NOINLINE Block* bqn_comp(B str, B path, B args) { // consumes all
   comp_currEnvPos = prevEnvPos;
   return r;
 }
-NOINLINE Block* bqn_compSc(B str, B path, B args, Scope* sc, bool repl) { // consumes str,path,args
+Block* bqn_compScc(B str, B path, B args, Scope* sc, B comp, B rt, bool repl) { // consumes str,path,args
   B   prevPath   = comp_currPath  ; comp_currPath = path;
   B   prevArgs   = comp_currArgs  ; comp_currArgs = args;
   B   prevSrc    = comp_currSrc   ; comp_currSrc  = str;
@@ -191,13 +191,24 @@ NOINLINE Block* bqn_compSc(B str, B path, B args, Scope* sc, bool repl) { // con
     csc = csc->psc;
     depth++;
   }
-  Block* r = load_compObj(c2(load_comp, m_hVec4(incG(load_rtObj), incG(bi_sys), vName, vDepth), inc(str)), str, path, sc);
+  Block* r = load_compObj(c2(comp, m_hVec4(incG(rt), incG(bi_sys), vName, vDepth), inc(str)), str, path, sc);
   dec(path); dec(args);
   comp_currPath   = prevPath;
   comp_currArgs   = prevArgs;
   comp_currSrc    = prevSrc;
   comp_currEnvPos = prevEnvPos;
   return r;
+}
+NOINLINE Block* bqn_compSc(B str, B path, B args, Scope* sc, bool repl) { // consumes str,path,args
+  return bqn_compScc(str, path, args, sc, load_comp, load_rtObj, repl);
+}
+void init_comp(B* set, B prim) { // doesn't consume
+  if (q_N(prim)) {
+    set[0] = inc(load_comp);
+    set[1] = inc(load_rtObj);
+  } else {
+    thrM("•ReBQN: primitives⇐ unimplemented");
+  }
 }
 
 B bqn_exec(B str, B path, B args) { // consumes all

--- a/src/vm.h
+++ b/src/vm.h
@@ -142,10 +142,12 @@ struct Scope {
 };
 
 Block* bqn_comp(B str, B path, B args);
-Block* bqn_compSc(B str, B path, B args, Scope* sc, bool repl);
+Block* bqn_compSc (B str, B path, B args, Scope* sc, bool repl);
+Block* bqn_compScc(B str, B path, B args, Scope* sc, B comp, B rt, bool repl);
 Block* compile(B bcq, B objs, B blocks, B bodies, B indices, B tokenInfo, B src, B path, Scope* sc);
 Scope* m_scope(Body* body, Scope* psc, u16 varAm, i32 initVarAm, B* initVars);
 Body* m_body(i32 vam, i32 pos, u32 maxStack, u16 maxPSC); // leaves varIDs and nsDesc uninitialized
+void init_comp(B* set, B prim);
 
 typedef struct Nvm_res { u8* p; B refs; } Nvm_res;
 Nvm_res m_nvm(Body* b);

--- a/src/vm.h
+++ b/src/vm.h
@@ -148,6 +148,7 @@ Block* compile(B bcq, B objs, B blocks, B bodies, B indices, B tokenInfo, B src,
 Scope* m_scope(Body* body, Scope* psc, u16 varAm, i32 initVarAm, B* initVars);
 Body* m_body(i32 vam, i32 pos, u32 maxStack, u16 maxPSC); // leaves varIDs and nsDesc uninitialized
 void init_comp(B* set, B prim);
+B rebqn_exec(B str, B path, B args, B comp, B rt);
 
 typedef struct Nvm_res { u8* p; B refs; } Nvm_res;
 Nvm_res m_nvm(Body* b);

--- a/src/vm.h
+++ b/src/vm.h
@@ -142,13 +142,12 @@ struct Scope {
 };
 
 Block* bqn_comp(B str, B path, B args);
-Block* bqn_compSc (B str, B path, B args, Scope* sc, bool repl);
-Block* bqn_compScc(B str, B path, B args, Scope* sc, B comp, B rt, bool repl);
+Block* bqn_compSc(B str, B path, B args, Scope* sc, bool repl);
 Block* compile(B bcq, B objs, B blocks, B bodies, B indices, B tokenInfo, B src, B path, Scope* sc);
 Scope* m_scope(Body* body, Scope* psc, u16 varAm, i32 initVarAm, B* initVars);
 Body* m_body(i32 vam, i32 pos, u32 maxStack, u16 maxPSC); // leaves varIDs and nsDesc uninitialized
 void init_comp(B* set, B prim);
-B rebqn_exec(B str, B path, B args, B comp, B rt);
+B rebqn_exec(B str, B path, B args, B o);
 
 typedef struct Nvm_res { u8* p; B refs; } Nvm_res;
 Nvm_res m_nvm(Body* b);

--- a/src/vm.h
+++ b/src/vm.h
@@ -141,13 +141,13 @@ struct Scope {
   B vars[];
 };
 
-Block* bqn_comp(B str, B path, B args);
-Block* bqn_compSc(B str, B path, B args, Scope* sc, bool repl);
+Block* bqn_comp(B str, B path, B args); // consumes all
+Block* bqn_compSc(B str, B path, B args, Scope* sc, bool repl); // consumes str,path,args
 Block* compile(B bcq, B objs, B blocks, B bodies, B indices, B tokenInfo, B src, B path, Scope* sc);
 Scope* m_scope(Body* body, Scope* psc, u16 varAm, i32 initVarAm, B* initVars);
 Body* m_body(i32 vam, i32 pos, u32 maxStack, u16 maxPSC); // leaves varIDs and nsDesc uninitialized
-void init_comp(B* set, B prim);
-B rebqn_exec(B str, B path, B args, B o);
+void init_comp(B* set, B prim); // doesn't consume; writes into first 3 elements of set
+B rebqn_exec(B str, B path, B args, B o); // consumes str,path,args
 
 typedef struct Nvm_res { u8* p; B refs; } Nvm_res;
 Nvm_res m_nvm(Body* b);


### PR DESCRIPTION
Adds support for `𝕩.primitives` in `•ReBQN` and `•primitives`. I've run a few tests with heapverify but it's definitely possible I've misunderstood some of the memory management stuff so you should probably review that.

This switches bytecode from the fixed-primitives compiler (c) to variable (cc). I've named the second "compiles" so the makefile can see it's not the same. The bytecode branch needs to be updated though.