### PR TITLE
ffi: make bqn_evalCStr use a constant string

### DIFF
--- a/include/bqnffi.h
+++ b/include/bqnffi.h
@@ -25,7 +25,7 @@ BQNV bqn_call2(BQNV f, BQNV w, BQNV x);
 
 // evaluate BQN code in a fresh environment
 BQNV bqn_eval(BQNV src);
-BQNV bqn_evalCStr(char* str); // evaluates the null-terminated UTF8-encoded str; equal to `BQNV s = bqn_makeUTF8Str(str, strlen(str)); result = bqn_eval(s); bqn_free(s);`
+BQNV bqn_evalCStr(const char* str); // evaluates the null-terminated UTF8-encoded str; equal to `BQNV s = bqn_makeUTF8Str(str, strlen(str)); result = bqn_eval(s); bqn_free(s);`
 
 
 // read array data

--- a/src/core/chrarr.h
+++ b/src/core/chrarr.h
@@ -20,7 +20,7 @@
 B m_str8(usz sz, char* s);
 B m_str8l(char* s);
 B m_str32(u32* s);
-B fromUTF8l(char* x);
+B fromUTF8l(const char* x);
 B fromUTF8a(I8Arr* x);
 
 C8Arr*  cpyC8Arr (B x); // consumes

--- a/src/ffi.c
+++ b/src/ffi.c
@@ -49,7 +49,7 @@ BQNV bqn_call2(BQNV f, BQNV w, BQNV x) {
 BQNV bqn_eval(BQNV src) {
   return makeX(bqn_exec(inc(getB(src)), bi_N, bi_N));
 }
-BQNV bqn_evalCStr(char* str) {
+BQNV bqn_evalCStr(const char* str) {
   return makeX(bqn_exec(fromUTF8l(str), bi_N, bi_N));
 }
 

--- a/src/utils/utf.c
+++ b/src/utils/utf.c
@@ -19,7 +19,7 @@ static u32 utf8_p(u8* p) {
   }
 }
 
-B fromUTF8(char* s, i64 len) {
+B fromUTF8(const char* s, i64 len) {
   u64 sz = 0;
   i64 j = 0;
   while (true) {
@@ -45,7 +45,7 @@ B fromUTF8(char* s, i64 len) {
   }
 }
 
-B fromUTF8l(char* s) {
+B fromUTF8l(const char* s) {
   return fromUTF8(s, strlen(s));
 }
 

--- a/src/utils/utf.h
+++ b/src/utils/utf.h
@@ -1,7 +1,7 @@
 #pragma once
 
-B fromUTF8(char* s, i64 len);
-B fromUTF8l(char* s);
+B fromUTF8(const char* s, i64 len);
+B fromUTF8l(const char* s);
 
 void printUTF8(u32 c);
 void fprintUTF8(FILE* f, u32 c);


### PR DESCRIPTION
This makes for example creating Rust bindings more idiomatic as it's very picky about the string types.