### PR TITLE
4-byte and 8-byte hashing for self-search functions

### DIFF
--- a/src/builtins/selfsearch.c
+++ b/src/builtins/selfsearch.c
@@ -160,14 +160,15 @@ B memberOf_c1(B t, B x) {
     return r;
   }
   #define BRUTE(T) \
-      i##T* xp = xv;                                                   \
-      u64* rp; B r = m_bitarrv(&rp, n); bitp_set(rp, 0, 1);            \
-      for (usz i=1; i<n; i++) {                                        \
-        bool c=1; i##T xi=xp[i];                                       \
-        for (usz j=0; j<i; j++) c &= xi!=xp[j];                        \
-        bitp_set(rp, i, c);                                            \
-      }                                                                \
-      decG(x); return r;
+    i##T* xp = xv;                                                     \
+    u64 rv = 1;                                                        \
+    for (usz i=1; i<n; i++) {                                          \
+      bool c=1; i##T xi=xp[i];                                         \
+      PLAINLOOP for (usz j=0; j<i; j++) c &= xi!=xp[j];                \
+      rv |= c<<i;                                                      \
+    }                                                                  \
+    decG(x); u64* rp; B r = m_bitarrv(&rp, n); rp[0] = rv;             \
+    return r;
   #define LOOKUP(T) \
     usz tn = 1<<T;                                                     \
     u##T* xp = (u##T*)xv;                                              \
@@ -239,14 +240,14 @@ B count_c1(B t, B x) {
   if (lw==0) { x = toI8Any(x); lw = cellWidthLog(x); }
   void* xv = tyany_ptr(x);
   #define BRUTE(T) \
-      i##T* xp = xv;                                           \
-      i8* rp; B r = m_i8arrv(&rp, n); rp[0]=0;                 \
-      for (usz i=1; i<n; i++) {                                \
-        usz c=0; i##T xi=xp[i];                                \
-        for (usz j=0; j<i; j++) c += xi==xp[j];                \
-        rp[i] = c;                                             \
-      }                                                        \
-      decG(x); return r;
+    i##T* xp = xv;                                             \
+    i8* rp; B r = m_i8arrv(&rp, n); rp[0]=0;                   \
+    for (usz i=1; i<n; i++) {                                  \
+      usz c=0; i##T xi=xp[i];                                  \
+      PLAINLOOP for (usz j=0; j<i; j++) c += xi==xp[j];        \
+      rp[i] = c;                                               \
+    }                                                          \
+    decG(x); return r;
   #define LOOKUP(T) \
     usz tn = 1<<T;                                             \
     u##T* xp = (u##T*)xv;                                      \
@@ -310,15 +311,15 @@ B indexOf_c1(B t, B x) {
     return shape_c1(m_f64(0), r);
   }
   #define BRUTE(T) \
-      i##T* xp = xv;                                           \
-      i8* rp; B r = m_i8arrv(&rp, n); rp[0]=0;                 \
-      TALLOC(i##T, uniq, n); uniq[0]=xp[0];                    \
-      for (usz i=1, u=1; i<n; i++) {                           \
-        bool c=1; usz s=0; i##T xi=uniq[u]=xp[i];              \
-        for (usz j=0; j<u; j++) s += (c &= xi!=uniq[j]);       \
-        rp[i]=s; u+=u==s;                                      \
-      }                                                        \
-      decG(x); TFREE(uniq); return r;
+    i##T* xp = xv;                                             \
+    i8* rp; B r = m_i8arrv(&rp, n); rp[0]=0;                   \
+    TALLOC(i##T, uniq, n); uniq[0]=xp[0];                      \
+    for (usz i=1, u=1; i<n; i++) {                             \
+      bool c=1; usz s=0; i##T xi=uniq[u]=xp[i];                \
+      for (usz j=0; j<u; j++) s += (c &= xi!=uniq[j]);         \
+      rp[i]=s; u+=u==s;                                        \
+    }                                                          \
+    decG(x); TFREE(uniq); return r;
   #define DOTAB(T) \
     i32 u=0;                                                   \
     for (usz i=0; i<n; i++) {                                  \
@@ -354,7 +355,7 @@ B indexOf_c1(B t, B x) {
     val -= dif; memset32(val, 0, dif); ,                   \
     /*AUXCLEAR*/val[j] = 0;, /*AUXMOVE*/val[k] = val[j];)
   if (lw==5) {
-    if (n<12) { BRUTE(32); }
+    if (n<16) { BRUTE(32); }
     B r;
     i32* rp; r = m_i32arrv(&rp, n);
     i32* xp = tyany_ptr(x);

--- a/src/builtins/selfsearch.c
+++ b/src/builtins/selfsearch.c
@@ -91,7 +91,7 @@ static NOINLINE void memset32(u32* p, u32 v, usz l) { for (usz i=0; i<l; i++) p[
 static NOINLINE void memset64(u64* p, u64 v, usz l) { for (usz i=0; i<l; i++) p[i]=v; }
 
 // Resizing hash table, with fallback
-#define SELFHASHTAB(T, W, RAD, STOP, RES0, RESULT, RESWRITE, THRESHMUL, THRESH, AUXSIZE, AUXINIT, AUXEXTEND, AUXCLEAR, AUXMOVE) \
+#define SELFHASHTAB(T, W, RAD, STOP, RES0, RESULT, RESWRITE, THRESHMUL, THRESH, AUXSIZE, AUXINIT, AUXEXTEND, AUXMOVE) \
   usz log = 64 - CLZ(n);                                                 \
   usz msl = (64 - CLZ(n+n/2)) + 1; if (RAD && msl>20) msl=20;            \
   usz sh = W - (msl<14? msl : 12+(msl&1)); /* Shift to fit to table */   \
@@ -133,7 +133,7 @@ static NOINLINE void memset64(u64* p, u64 v, usz l) { for (usz i=0; i<l; i++) p[
       memset##W(hash, x0, dif);                                          \
       AUXEXTEND                                                          \
       for (j = dif; j < sz + ext; j++) {                                 \
-        T h = hash[j]; if (h==x0) continue; hash[j] = x0; AUXCLEAR       \
+        T h = hash[j]; if (h==x0) continue; hash[j] = x0;                \
         T k0 = h>>sh, k = k0; while (hash[k]!=x0) k++;                   \
         cc += k-k0;                                                      \
         hash[k] = h; AUXMOVE                                             \
@@ -185,9 +185,9 @@ B memberOf_c1(B t, B x) {
   #define HASHTAB(T, W, RAD, STOP, THRESH) T* xp = (T*)xv; SELFHASHTAB( \
     T, W, RAD, STOP,                                    \
     1, taga(cpyBitArr(r)), hash[j]=h; rp[i]=k!=h;,      \
-    1, THRESH, 0,,,,)
+    1, THRESH, 0,,,)
   if (lw == 5) {
-    if (n<=12) { BRUTE(32); }
+    if (n<12) { BRUTE(32); }
     i8* rp; B r = m_i8arrv(&rp, n);
     HASHTAB(u32, 32, 1, n/2, sz==msz? 1 : sz>=(1<<15)? 3 : 5)
 
@@ -213,7 +213,7 @@ B memberOf_c1(B t, B x) {
     return taga(cpyBitArr(r));
   }
   if (lw == 6 && canCompare64_norm(x, n)) {
-    if (n<=20) { BRUTE(64); }
+    if (n<20) { BRUTE(64); }
     i8* rp; B r = m_i8arrv(&rp, n);
     HASHTAB(u64, 64, 0, n, sz==msz? 0 : sz>=(1<<18)? 0 : sz>=(1<<14)? 3 : 5)
     decG(r); // Fall through
@@ -351,11 +351,10 @@ B indexOf_c1(B t, B x) {
     u32* val = (u32*)(hash+sz+ext) + msz-sz;               \
     memset32(val, 0, sz+ext);                              \
     u32 ctr = 1; ,                                         \
-    /* AUXEXTEND */                                        \
-    val -= dif; memset32(val, 0, dif); ,                   \
-    /*AUXCLEAR*/val[j] = 0;, /*AUXMOVE*/val[k] = val[j];)
+    /*AUXEXTEND*/val -= dif; memset32(val, 0, dif); ,      \
+    /*AUXMOVE*/u32 v = val[j]; val[j] = 0; val[k] = v;)
   if (lw==5) {
-    if (n<16) { BRUTE(32); }
+    if (n<12) { BRUTE(32); }
     B r;
     i32* rp; r = m_i32arrv(&rp, n);
     i32* xp = tyany_ptr(x);
@@ -378,7 +377,7 @@ B indexOf_c1(B t, B x) {
     decG(r); // Fall through
   }
   if (lw==6 && canCompare64_norm(x, n)) {
-    if (n<12) { BRUTE(64); }
+    if (n<16) { BRUTE(64); }
     i32* rp; B r = m_i32arrv(&rp, n);
     u64* xp = tyany_ptr(x);
     HASHTAB(u64, 64, sz==msz? 0 : sz>=(1<<17)? 1 : sz>=(1<<13)? 4 : 6)

--- a/src/builtins/selfsearch.c
+++ b/src/builtins/selfsearch.c
@@ -28,11 +28,12 @@ static bool canCompare64_norm(B x, usz n) {
   u8 e = TI(x,elType);
   if (e == el_B) return 0;
   if (e == el_f64) {
-    f64* p = f64any_ptr(x);
+    f64* pf = f64any_ptr(x);
+    u64* pu = (u64*)pf;
     for (usz i = 0; i < n; i++) {
-      f64 v = p[i];
-      if (v!=v) return 0;
-      if (v==0) p[i]=0;
+      f64 f = pf[i];
+      if (f!=f) return 0;
+      if (pu[i] == m_f64(-0.0).u) return 0;
     }
   }
   return 1;
@@ -156,7 +157,7 @@ static NOINLINE void memset64(u64* p, u64 v, usz l) { for (usz i=0; i<l; i++) p[
 
 B memberOf_c1(B t, B x) {
   if (isAtm(x) || RNK(x)==0) thrM("∊: Argument cannot have rank 0");
-  usz n = *SH(x);
+  u64 n = *SH(x);
   if (n<=1) { decG(x); return n ? taga(arr_shVec(allOnes(1))) : emptyIVec(); }
   
   u8 lw = cellWidthLog(x);
@@ -241,7 +242,7 @@ B memberOf_c1(B t, B x) {
 
 B count_c1(B t, B x) {
   if (isAtm(x) || RNK(x)==0) thrM("⊒: Argument cannot have rank 0");
-  usz n = *SH(x);
+  u64 n = *SH(x);
   if (n<=1) { decG(x); return n ? taga(arr_shVec(allZeroes(1))) : emptyIVec(); }
   if (n>(usz)I32_MAX+1) thrM("⊒: Argument length >2⋆31 not supported");
   
@@ -326,7 +327,7 @@ B count_c1(B t, B x) {
 
 B indexOf_c1(B t, B x) {
   if (isAtm(x) || RNK(x)==0) thrM("⊐: 𝕩 cannot have rank 0");
-  usz n = *SH(x);
+  u64 n = *SH(x);
   if (n<=1) { decG(x); return n ? taga(arr_shVec(allZeroes(1))) : emptyIVec(); }
   if (n>(usz)I32_MAX+1) thrM("⊐: Argument length >2⋆31 not supported");
   


### PR DESCRIPTION
Up to 5x faster than radix lookups in the 20 to 1e5 range (mostly below 2e3 or so). The derivation for that crazy test `(n-i)*dc < (i*((i64)n+i))>>(5+log-(W-sh))` is [here](https://mlochbaum.github.io/BQN/implementation/primitive/search.html#resizing-math). `dc` is `ct-d×i` and `log-(W-sh)` is approximately the log of `n÷s`.