### PR TITLE
Add target `make musl-static`

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Alternatively, `build/build` (aka build.bqn) can be invoked manually, though not
 - `make wasi-o3` - build targeting WASI
 - `make wasi-reactor-o3` - build producing a WASI Reactor
 - `make debug` - unoptimized build with extra assertion checks (also includes `-g`)
+- `make static-bin` - build a statically linked executable (for a fully standalone binary, try `make static-bin CC=musl-gcc REPLXX=0`)
 
 All of the above will go through build.bqn. If that causes problems, `make o3-makeonly` or `make c-makeonly` can be used. These still enable REPLXX by default, but do not support Singeli. Furthermore, these targets don't support some of the build flags that the others do.
 

--- a/makefile
+++ b/makefile
@@ -80,6 +80,8 @@ shared-o3:
 	@"${MAKE}" to-bqn-build REPLXX=0 i_SHARED=1
 shared-c:
 	@"${MAKE}" to-bqn-build REPLXX=0 i_SHARED=1 i_build_opts=c
+static-bin:
+	@"${MAKE}" to-bqn-build FFI=0 LDFLAGS="-static"
 
 # mappings of old names
 o3-singeli: o3


### PR DESCRIPTION
Another thing I need for the BQN slack bot that I've just done manually until now: building a binary on a modern machine that works on any ancient cloud runtime. This assumes the same platform – I've only tested on x86-64 Linux.