### PR TITLE
use the same file name as output for cached file

### DIFF
--- a/build/src/build.bqn
+++ b/build/src/build.bqn
@@ -741,7 +741,7 @@ cachedBin‿linkerCache ← {
     objs∾↩ ⋈ MakeCCInv ⟨po.CBQNc, ⊢, linkerCache, "versionInfo", srcFile, ⟨⟩⟩
   }
   
-  res ← MakeLinkerInv ⟨po.Linker, linkerCache, {po.emcc? "BQN.js"; "windows"≡po.os? "res.exe"; "res"}, objs⟩
+  res ← MakeLinkerInv ⟨po.Linker, linkerCache, {po.emcc? "BQN.js"; •file.Name po.output}, objs⟩
   
   res.dst ⋈ linkerCache
 }


### PR DESCRIPTION
For Windows, the original file name is written into the binary, which can cause problems when linking