### PR TITLE
:recycle: align ←

### DIFF
--- a/test/various.bqn
+++ b/test/various.bqn
@@ -30,10 +30,10 @@ BitSlash ← {ty‿dy‿max𝕊n:
   f ← dy ⊑ ⟨/∘⊢ ⋄ {𝕩/ty V 𝕨 R 100}⟩
   {𝕊:
     # 𝕩⊸{•Show 𝕨}⍟⊢ 0=10000|𝕩
-    t1←20 RH 100
-    n←R max
-    x←n F n↑RB2 128+n
-    t2←20 RH 100
+    t1 ← 20 RH 100
+    n  ← R max
+    x  ← n F n↑RB2 128+n
+    t2 ← 20 RH 100
     x↩0 ⋄ t1 CH↩ ⋄ t2 CH↩
   }¨↕n
 }


### PR DESCRIPTION
A similar to PR to https://github.com/mlochbaum/bqn-libs/pull/6 for Marshall's `bqn-libs`. Quote from that PR:

> The main reason I am doing this is to get the BQN X% to show up. It seems any library with BQN needs a commit since BQN was a recognized language to get the % to show up. Plus alignment is nice.