### PR TITLE
replace usage of bash with /bin/sh

### DIFF
--- a/build/build
+++ b/build/build
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 DIR="$(dirname $0)"
 PREV_BQN="$DIR/obj2/for_build4"
 if [ ! -f "$PREV_BQN" ]; then

--- a/build/makefile
+++ b/build/makefile
@@ -1,4 +1,3 @@
-SHELL = /usr/bin/env bash
 MAKEFLAGS+= --no-print-directory --no-builtin-rules --no-builtin-variables
 MAKEHERE = "$(MAKE) -f build/makefile"
 # note: do not manually define any i_… arguments, or incremental compiling may not work properly!

--- a/makefile
+++ b/makefile
@@ -1,4 +1,3 @@
-SHELL = /usr/bin/env bash
 MAKEFLAGS+= --no-print-directory --no-builtin-rules --no-builtin-variables
 
 default: o3

--- a/test/mainCfgs.sh
+++ b/test/mainCfgs.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 if [ "$#" -ne 1 ]; then
   echo "Usage: $0 path/to/mlochbaum/BQN"
   exit

--- a/test/moreCfgs.sh
+++ b/test/moreCfgs.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 if [ "$#" -ne 1 ]; then
   echo "Usage: $0 path/to/mlochbaum/BQN"
   exit

--- a/test/x86Cfgs.sh
+++ b/test/x86Cfgs.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 if [ "$#" -ne 1 ]; then
   echo "Usage: $0 path/to/mlochbaum/BQN"
   exit


### PR DESCRIPTION
This avoids an extra dependency on distributions that don't ship bash by default. All scripts work with /bin/sh just fine as far as I tested.