### PR TITLE
build: fix on systems with bmake as make impl

### DIFF
--- a/build/build
+++ b/build/build
@@ -3,7 +3,7 @@ DIR="$(dirname $0)"
 PREV_BQN="$DIR/obj2/for_build4"
 if [ ! -f "$PREV_BQN" ]; then
   TMP_BQN="$DIR/obj2/for_build_tmp"
-  if make -C "$DIR/.." for-build OUTPUT="$TMP_BQN"; then
+  if "${MAKE:-make}" -C "$DIR/.." for-build OUTPUT="$TMP_BQN"; then
     if [ "4" = "$("$TMP_BQN" -p "2+2")" ]; then
       true
     else

--- a/makefile
+++ b/makefile
@@ -83,7 +83,7 @@ endif
 ifeq ($(origin clean),command line)
 	@echo "Error: build-specific 'clean' unsupported"; false
 endif
-	@build/build from-makefile CC="$(CC)" CXX="$(CXX)" PIE="$(ENABLE_PIE)" OUTPUT="$(OUTPUT)" j="$(j)" \
+	@MAKE="$(MAKE)" build/build from-makefile CC="$(CC)" CXX="$(CXX)" PIE="$(ENABLE_PIE)" OUTPUT="$(OUTPUT)" j="$(j)" \
 	  verbose="$(verbose)" notui="$(notui)" v="$(version)" stored-warn="$(stored-warn)" \
 	  f="$(f)" lf="$(lf)" CCFLAGS="$(CCFLAGS)" LDFLAGS="$(LDFLAGS)" REPLXX_FLAGS="$(REPLXX_FLAGS)" CXXFLAGS="$(CXXFLAGS)" \
 	  LD_LIBS="$(LD_LIBS)" NO_LDL="$(NO_LDL)" no_fPIC="$(no_fPIC)" target-from-cc="$(target_from_cc)" \


### PR DESCRIPTION
For example, on FreeBSD, bmake is the default make implementation. Thus, to build CBQN, we must use 'gmake' invocations. This patch fixes the hardcoded call to 'make' in build/build.