### PR TITLE
Add repology packaging status

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [CBQN-specific documentation](docs/README.md) • [source code overview](src/README.md)
 
+[![Packaging status](https://repology.org/badge/vertical-allrepos/cbqn.svg)](https://repology.org/project/cbqn/versions)
+
 ## Running
 
 1. `make`


### PR DESCRIPTION
I just added a new package for alpinelinux and thought that this might be helpful for users to quickly find which distros have CBQN packages. Feel free to move the badge around in the README to wherever it fits best.