### PR TITLE
Add ANSI escape code for errors

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -1732,7 +1732,7 @@ NOINLINE NORETURN void throwImpl(bool rethrow) {
   } else { // uncaught error
 #endif
     assert(cf==cfStart);
-    fprintf(stderr, "Error: "); printErrMsg(thrownMsg); fprintf(stderr,"\n"); fflush(stderr);
+    fprintf(stderr, RED "Error" RESET ": "); printErrMsg(thrownMsg); fprintf(stderr,"\n"); fflush(stderr);
     Env* envEnd = envStart+envPrevHeight;
     unwindEnv(envStart-1);
     vm_pst(envCurr+1, envEnd);

--- a/src/vm.c
+++ b/src/vm.c
@@ -23,10 +23,10 @@
                   F(SETNi)F(SETUi)F(SETMi)F(SETCi)F(SETNv)F(SETUv)F(SETMv)F(SETCv)F(PRED1)F(PRED2)F(SETH1)F(SETH2) \
                   F(DFND0)F(DFND1)F(DFND2)F(FAIL)
 
-#define RED        "\033[31m"
-#define GRAY       "\033[90m"
-#define WHITE      "\033[97m"
-#define RESET      "\033[0m"
+#define RED       "\033[31m"
+#define GRAY      "\033[90m"
+#define WHITE     "\033[97m"
+#define RESET     "\033[0m"
 
 char* bc_repr(u32 p) {
   switch(p) { default: return "(unknown)";

--- a/src/vm.c
+++ b/src/vm.c
@@ -23,6 +23,10 @@
                   F(SETNi)F(SETUi)F(SETMi)F(SETCi)F(SETNv)F(SETUv)F(SETMv)F(SETCv)F(PRED1)F(PRED2)F(SETH1)F(SETH2) \
                   F(DFND0)F(DFND1)F(DFND2)F(FAIL)
 
+#define RED        "\033[31m"
+#define GRAY       "\033[90m"
+#define WHITE      "\033[97m"
+#define RESET      "\033[0m"
 
 char* bc_repr(u32 p) {
   switch(p) { default: return "(unknown)";
@@ -1350,11 +1354,13 @@ NOINLINE B vm_fmtPoint(B src, B prepend, B path, usz cs, usz ce) { // consumes p
   i64 ln = 1;
   for (usz i = 0; i < srcS; i++) if(o2cG(GetU(src, i))=='\n') ln++;
   B s = prepend;
+  AFMT(GRAY);
   if (!isArr(path) || path.u==replName.u || IA(path)==0) AFMT("at ");
-  else AFMT("%R:%l:\n  ", path, ln);
+  else AFMT("%R:"RESET"%l"GRAY":\n  ", path, ln);
   i64 padEnd = (i64)IA(s);
   i64 padStart = padEnd;
   SGetU(s)
+  AFMT(RESET);
   while (padStart>0 && o2cG(GetU(s,padStart-1))!='\n') padStart--;
   
   AJOIN(taga(arr_shVec(TI(src,slice)(incG(src),srcS, srcE-srcS))));
@@ -1363,7 +1369,9 @@ NOINLINE B vm_fmtPoint(B src, B prepend, B path, usz cs, usz ce) { // consumes p
   ACHR('\n');
   for (i64 i = padStart; i < padEnd; i++) ACHR(' ');
   for (u64 i = 0; i < cs; i++) ACHR(o2cG(GetU(src, srcS+i))=='\t'? '\t' : ' '); // ugh tabs
+  AFMT(RED);
   for (u64 i = cs; i < ce; i++) ACHR('^');
+  AFMT(RESET);
   return s;
 }
 


### PR DESCRIPTION
Using ANSI color codes, it adds some colors to error messages.

It turns

![image](https://github.com/user-attachments/assets/7a06f269-cf5b-4f0e-ad04-38de20086f28)

into: 

![image](https://github.com/user-attachments/assets/a528d8ff-2aee-4bf2-a774-5302c1110328)

I'm happy to make this an opt-in `--color` option when running `BQN`, or any other changes. 

I'm also not clear on what `FORCE_NATIVE_ERROR_PRINT` is meant for, or if there's a more idiomatic way of adding color highlighting to error message, so if this is a welcome change, let me know what I can do to make it better!