### PR TITLE
feat(explain): Allow `)explain` to recognize REPL variables

### DIFF
--- a/src/load.c
+++ b/src/load.c
@@ -650,7 +650,7 @@ void bqn_exit(i32 code) {
 }
 
 STATIC_GLOBAL B load_explain;
-B bqn_explain(B str) {
+B bqn_explain(B str, B vars) { // consumes str & vars
   #if NO_EXPLAIN
     thrM("Explainer not included in this CBQN build");
   #else
@@ -663,9 +663,22 @@ B bqn_explain(B str) {
       gc_add(load_explain = evalFunBlockConsume(expl_b));
     }
     
+    B c;
     COMPS_PUSH(str, bi_N, def_re);
-    B c = c2(o[re_compFn], incG(o[re_compOpts]), inc(str));
-    COMPS_POP;
+    B compOpts;
+    if (q_N(vars) || IA(vars) == 0) {
+      compOpts = incG(o[re_compOpts]);
+      if (!q_N(vars)) decG(vars);
+    } else {
+      usz n = IA(vars);
+      i32* p;
+      B vDepth = m_i32arrv(&p, n);
+      for (usz i=0; i<n; i++) p[i] = 0;
+      compOpts = m_lvB_4(incG(o[re_rt]), incG(bi_sys), vars, vDepth);
+    }
+    c = c2(o[re_compFn], compOpts, inc(str));
+    COMPS_POP; popCatch();
+    
     B ret = c2(load_explain, c, str);
     return ret;
   #endif

--- a/src/load.c
+++ b/src/load.c
@@ -670,10 +670,7 @@ B bqn_explain(B str, B vars) { // consumes str & vars
       compOpts = incG(o[re_compOpts]);
       if (!q_N(vars)) decG(vars);
     } else {
-      usz n = IA(vars);
-      i32* p;
-      B vDepth = m_i32arrv(&p, n);
-      for (usz i=0; i<n; i++) p[i] = 0;
+      B vDepth = i64EachDec(-1, incG(vars));
       compOpts = m_lvB_4(incG(o[re_rt]), incG(bi_sys), vars, vDepth);
     }
     c = c2(o[re_compFn], compOpts, inc(str));

--- a/src/load.h
+++ b/src/load.h
@@ -26,7 +26,7 @@ void comps_getSysvals(B* res);
 typedef struct Block Block;
 typedef struct Scope Scope;
 NOINLINE B load_fullpath(B path, B name); // doesn't consume
-B bqn_explain(B str); // consumes str
+B bqn_explain(B str, B vars); // consumes str & vars
 B bqn_execFile(B path, B args); // consumes both
 B bqn_execFileRe(B path, B args, B re); // consumes path,args
 Block* bqn_comp   (B str, B state); // consumes both

--- a/src/main.c
+++ b/src/main.c
@@ -807,7 +807,8 @@ void cbqn_runLine0(char* ln, i64 read) {
       return;
 #endif
     } else if (isCmd(cmdS, &cmdE, "e ") || isCmd(cmdS, &cmdE, "explain ")) {
-      HArr* expla = toHArr(bqn_explain(utf8Decode0(cmdE)));
+      B vars = listVars(gsc);
+      HArr* expla = toHArr(bqn_explain(utf8Decode0(cmdE), vars));
       usz ia=PIA(expla);
       for(usz i=0; i<ia; i++) {
         printsB(expla->a[i]);


### PR DESCRIPTION
This change enhances the `)explain` REPL command to provide context from the current session's variables. Previously, `)explain` would fail with an "Undefined identifier" error if the expression contained variables defined in the REPL.

The `bqn_explain` function now accepts a list of variable names from the REPL scope. During compilation, if thi list is provided, the compiler options are updated to include these variables at a depth of 0, allowing expressions to be explained correctly without needing the actual variable values.

This means users can now explain expressions like `)e {≠÷+´𝕩} t` after `t` has been defined in the REPL, resolving the previous limitation.